### PR TITLE
Fix readme for protocol_splitter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Options available:
   -d <uart_device>		UART device. Default /dev/ttyUSB0
   -i <host_ip>			Host IP for UDP. Default 127.0.0.1
   -w <mavlink_udp_recv_port>	UDP port for receiving. Default 5800
-  -x <mavlink_udp_send_port>	UDP port for receiving. Default 5801
+  -x <mavlink_udp_send_port>	UDP port for sending. Default 5801
   -y <rtps_udp_recv_port>	UDP port for receiving. Default 5900
-  -z <rtps_udp_send_port>	UDP port for receiving. Default 5901
-  -f <sw_flow_control>		Activates UART link SW flow control
-  -h <hw_flow_control>		Activates UART link HW flow control
-  -v <verbose_debug>		Add more verbosity
+  -z <rtps_udp_send_port>	UDP port for sending. Default 5901
+  -f Activates UART link SW flow control
+  -g Activates UART link HW flow control
+  -v Add more verbosity
 ```
 
 At the same time, the `protocol_splitter` should also be run in the client side, so the stream can be multiplexed bidirectionally.


### PR DESCRIPTION
This PR fixes the read me of the `protocol_splitter` command line options

I deleted `<>` tags which doesn't consume any parameters from the command line