### PR TITLE
4-byte header with checksum over payload len

### DIFF
--- a/include/protocol_splitter.hpp
+++ b/include/protocol_splitter.hpp
@@ -62,16 +62,27 @@ struct StaticData {
 
 /*
 struct Sp2Header {
-	char magic[3];
-	uint8_t type;
-	uint16_t payload_len;
-	uint16_t reserved (align)
+	char magic;                // 'S'
+	uint8_t type:1;            // 0=MAVLINK, 1=RTPS
+	uint16_t payload_len:15;   // Length
+	uint8_t checksum;          // XOR of two above bytes
 }
-*/
 
+     bits:   1 2 3 4 5 6 7 8
+header[0] - |     Magic     |
+header[1] - |T|   LenH      |
+header[2] - |     LenL      |
+header[3] - |   Checksum    |
+
+MessageType is in MSB of header[1]
+            |
+            v
+    Mavlink 0000 0000b
+    Rtps    1000 0000b
+*/
 enum MessageType {
-	Mavlink = 0,
-	Rtps
+	Mavlink = 0x00,
+	Rtps    = 0x80
 };
 
 volatile sig_atomic_t running = true;
@@ -93,8 +104,8 @@ namespace
 {
 static StaticData *objects = nullptr;
 
-const char* Sp2HeaderMagic = "SP2";
-const int   Sp2HeaderSize  = 8;
+const char Sp2HeaderMagic = 'S';
+const int  Sp2HeaderSize  = 4;
 
 }
 


### PR DESCRIPTION
Header size is reduced from 8-bytes to 4-bytes. This is done by reducing the identifier magic bytes from 3 to 1, including the message type into one bit (either mavlink or rtps) in the MSB of second length byte and finally removing the reserved alignment bytes in the end of header. To compensate reduction of magic bytes and keep detection robust the last byte is used as a checksum over header (excluding the magic byte).