### PR TITLE
Robustify protocol splitter header check

### DIFF
--- a/include/protocol_splitter.hpp
+++ b/include/protocol_splitter.hpp
@@ -96,7 +96,7 @@ typedef union __attribute__((packed))
 		uint8_t len_h:	7,         // Length MSB
 			 type:	1;         // 0=MAVLINK, 1=RTPS
 		uint8_t len_l;             // Length LSB
-		uint8_t checksum;          // XOR of two above bytes
+		uint8_t checksum;          // XOR of the three bytes above
 	} fields;
 } Sp2Header_t;
 

--- a/src/protocol_splitter.cpp
+++ b/src/protocol_splitter.cpp
@@ -93,10 +93,6 @@ int DevSerial::open_uart()
 		// 8 bits
 		uart_config.c_cflag |= CS8;
 
-		// use epoll to get notification of available bytes
-		uart_config.c_cc[VMIN] = 0;
-		uart_config.c_cc[VTIME] = 0;
-
 		// Flow control
 		if (_hw_flow_control) {
 			// HW flow control


### PR DESCRIPTION
This makes sure we don't assume invalid headers as valid. The changes include:

1. Add the magic byte to the checksum XOR;
2. Check if the payload length is 0, and if yes, discard the packet.