### PR TITLE
Update UART fd open and close

### DIFF
--- a/src/protocol_splitter.cpp
+++ b/src/protocol_splitter.cpp
@@ -46,6 +46,7 @@ DevSerial::DevSerial(const char *device_name, const uint32_t baudrate, const boo
 DevSerial::~DevSerial()
 {
 	if (_uart_fd >= 0) {
+		tcflush(_uart_fd, TCIOFLUSH);
 		close();
 	}
 }

--- a/src/protocol_splitter.cpp
+++ b/src/protocol_splitter.cpp
@@ -153,13 +153,6 @@ int DevSerial::open_uart()
 
 		printf("[ protocol__splitter ]\tUART link: device: %s; baudrate: %d; flow_control: %s\n",
 		       _uart_name, _baudrate, _sw_flow_control ? "SW enabled" : (_hw_flow_control ? "HW enabled" : "No"));
-
-		char aux[64];
-
-		while (0 < ::read(_uart_fd, (void *)&aux, 64)) {
-			printf("[ protocol__splitter ]\tUART link: Flushed\n");
-			usleep(1000);
-		}
 	}
 
 	return _uart_fd;


### PR DESCRIPTION
- Removing a redundant read from UART in open, to avoid occasional busy looping
- Flushing the fd on close