### PR TITLE
Decrease maximum buffer size

### DIFF
--- a/include/protocol_splitter.hpp
+++ b/include/protocol_splitter.hpp
@@ -49,7 +49,7 @@
 #include <linux/serial.h>
 #endif
 
-#define BUFFER_SIZE			2048
+#define BUFFER_SIZE			280*3 // Maximum MAVLink message length, three times
 #define DEFAULT_BAUDRATE 		460800
 #define DEFAULT_UART_DEVICE		"/dev/ttyUSB0"
 #define DEFAULT_HOST_IP			"127.0.0.1"


### PR DESCRIPTION
There are receiving UDP sockets that don't allocate buffers for a 2048 byte datagrams and as a result portions of the sent data might be discarded (e.g. mavlink-router allocates 280*4 bytes). Reducing the packet size lowers the risk of lost data when transmitting a lot of messages. The discarded data can lead to malformed MAVLink messages since they are put together with partial data from two subsequent UDP packets.
The alternative solution would be to increase the buffer on the receiving side (e.g. in mavlink-router) but if this is statically allocated then the memory usage of all endpoints increases. For example, mavlink-router config in AuterionOS has 16+ endpoints and most of them don't need the increased buffer size.

## Testing
I only tested with MAVLink pass-through and there it is working.

## Additional Info
I added a check in mavlink-router which prints a message when the datagram size exceeds the available buffer size, output below.
1. The check is triggered very frequently and a lot of data is lost.
2. Every time the check triggers, also the CRC check fails for the read MAVLink message.
3. If the message is cut before the message ID, then the resulting message might have an unknown ID and are not discarded by the CRC check. As a result there are corrupted MAVLink messages sent out to all receiving endpoints. These events correlate with `No message entry for` prints.

Before:
```
Feb 17 13:34:28 astro mavlink-routerd[11242]: Logging target system_id=1 on 00145-2022-02-17_13-34-28.ulg
Feb 17 13:34:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:34:54 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1024 > 872
Feb 17 13:34:54 astro mavlink-routerd[11242]: CRC check failed 266 55
Feb 17 13:35:00 astro mavlink-routerd[11242]: 2 messages to unknown endpoints in the last 5 seconds
Feb 17 13:35:05 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:35:31 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1174 > 1029
Feb 17 13:35:31 astro mavlink-routerd[11242]: CRC check failed 266 7
Feb 17 13:35:44 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1289 > 863
Feb 17 13:35:44 astro mavlink-routerd[11242]: CRC check failed 266 147
Feb 17 13:36:50 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:36:55 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:37:02 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1557 > 1120
Feb 17 13:37:02 astro mavlink-routerd[11242]: CRC check failed 266 17
Feb 17 13:37:02 astro mavlink-routerd[11242]: CRC check failed 0 0
Feb 17 13:37:57 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1428 > 897
Feb 17 13:37:57 astro mavlink-routerd[11242]: CRC check failed 266 76
Feb 17 13:38:22 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1667 > 1120
Feb 17 13:38:22 astro mavlink-routerd[11242]: CRC check failed 266 148
Feb 17 13:38:40 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:38:45 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:39:20 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1024 > 860
Feb 17 13:39:20 astro mavlink-routerd[11242]: CRC check failed 266 66
Feb 17 13:39:35 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1290 > 1120
Feb 17 13:39:35 astro mavlink-routerd[11242]: CRC check failed 266 228
Feb 17 13:40:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:40:32 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1286 > 1120
Feb 17 13:40:32 astro mavlink-routerd[11242]: CRC check failed 266 124
Feb 17 13:40:36 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1662 > 1120
Feb 17 13:40:36 astro mavlink-routerd[11242]: CRC check failed 266 179
Feb 17 13:40:36 astro mavlink-routerd[11242]: CRC check failed 21 192
Feb 17 13:40:40 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:41:14 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1607 > 1120
Feb 17 13:41:14 astro mavlink-routerd[11242]: CRC check failed 266 212
Feb 17 13:41:14 astro mavlink-routerd[11242]: No message entry for 14 21
Feb 17 13:42:25 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:42:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:42:59 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1024 > 967
Feb 17 13:42:59 astro mavlink-routerd[11242]: CRC check failed 266 138
Feb 17 13:43:08 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1466 > 1120
Feb 17 13:43:08 astro mavlink-routerd[11242]: CRC check failed 93 240
Feb 17 13:43:38 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1024 > 875
Feb 17 13:43:38 astro mavlink-routerd[11242]: CRC check failed 266 66
Feb 17 13:44:15 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:44:20 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:44:33 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1381 > 1120
Feb 17 13:44:33 astro mavlink-routerd[11242]: CRC check failed 266 49
Feb 17 13:44:38 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1155 > 945
Feb 17 13:44:38 astro mavlink-routerd[11242]: CRC check failed 266 103
Feb 17 13:44:42 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 945 > 871
Feb 17 13:44:42 astro mavlink-routerd[11242]: CRC check failed 93 152
Feb 17 13:45:52 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1197 > 1120
Feb 17 13:45:52 astro mavlink-routerd[11242]: CRC check failed 266 155
Feb 17 13:46:10 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:46:13 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 938 > 875
Feb 17 13:46:13 astro mavlink-routerd[11242]: CRC check failed 266 181
Feb 17 13:46:15 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:47:50 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1229 > 968
Feb 17 13:47:50 astro mavlink-routerd[11242]: CRC check failed 266 133
Feb 17 13:48:00 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:48:05 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:49:05 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 916 > 875
Feb 17 13:49:05 astro mavlink-routerd[11242]: CRC check failed 93 235
Feb 17 13:49:16 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1342 > 1120
Feb 17 13:49:16 astro mavlink-routerd[11242]: CRC check failed 266 203
Feb 17 13:49:50 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:50:00 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:50:05 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1413 > 1120
Feb 17 13:50:05 astro mavlink-routerd[11242]: CRC check failed 266 29
Feb 17 13:50:40 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 2048 > 1120
Feb 17 13:50:40 astro mavlink-routerd[11242]: CRC check failed 266 54
Feb 17 13:50:40 astro mavlink-routerd[11242]: CRC check failed 0 0
Feb 17 13:51:45 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:51:50 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:51:55 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1219 > 1120
Feb 17 13:51:55 astro mavlink-routerd[11242]: CRC check failed 266 19
Feb 17 13:53:22 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1024 > 1023
Feb 17 13:53:22 astro mavlink-routerd[11242]: CRC check failed 266 227
Feb 17 13:53:35 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:53:40 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:54:18 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1345 > 1120
Feb 17 13:54:18 astro mavlink-routerd[11242]: CRC check failed 266 162
Feb 17 13:54:58 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1024 > 956
Feb 17 13:54:58 astro mavlink-routerd[11242]: CRC check failed 266 139
Feb 17 13:54:59 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 2048 > 873
Feb 17 13:54:59 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1615 > 1090
Feb 17 13:54:59 astro mavlink-routerd[11242]: CRC check failed 93 55
Feb 17 13:54:59 astro mavlink-routerd[11242]: CRC check failed 266 75
Feb 17 13:54:59 astro mavlink-routerd[11242]: No message entry for 1492992 0
Feb 17 13:55:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:55:35 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 13:56:45 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1306 > 1120
Feb 17 13:56:45 astro mavlink-routerd[11242]: CRC check failed 266 208
Feb 17 13:57:09 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 971 > 955
Feb 17 13:57:09 astro mavlink-routerd[11242]: CRC check failed 266 209
Feb 17 13:58:00 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1160 > 1119
Feb 17 13:58:00 astro mavlink-routerd[11242]: CRC check failed 93 121
Feb 17 13:58:19 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 914 > 875
Feb 17 13:58:19 astro mavlink-routerd[11242]: CRC check failed 93 16
Feb 17 14:00:32 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 1234 > 1120
Feb 17 14:00:32 astro mavlink-routerd[11242]: CRC check failed 266 36
Feb 17 14:00:35 astro mavlink-routerd[11242]: 7 messages to unknown endpoints in the last 5 seconds
Feb 17 14:01:41 astro mavlink-routerd[11242]: EP UDP [6]: Datagram larger than buffer: 895 > 875
Feb 17 14:01:41 astro mavlink-routerd[11242]: CRC check failed 93 191
Feb 17 14:01:41 astro mavlink-routerd[11242]: CRC check failed 22 97
```

After:
```
Feb 17 14:04:59 astro mavlink-routerd[11242]: Logging target system_id=1 on 00146-2022-02-17_14-04-59.ulg
Feb 17 14:05:00 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:06:25 astro mavlink-routerd[11242]: 2 messages to unknown endpoints in the last 5 seconds
Feb 17 14:06:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:09:15 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:09:20 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:12:05 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:12:15 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:15:00 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:15:05 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:17:50 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:18:00 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:20:45 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:20:50 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:23:40 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:23:45 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:24:22 astro mavlink-routerd[11242]: CRC check failed 266 178
Feb 17 14:26:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:26:40 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:29:25 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:29:30 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:32:20 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:32:25 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:35:10 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:35:20 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:38:05 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:38:10 astro mavlink-routerd[11242]: 1 messages to unknown endpoints in the last 5 seconds
Feb 17 14:39:24 astro mavlink-routerd[11242]: CRC check failed 266 237
```

FYI @cmic0 @DanielePettenuzzo 